### PR TITLE
Feature: Optional disableContentCheck parameter

### DIFF
--- a/Bundle.ecl
+++ b/Bundle.ecl
@@ -7,5 +7,5 @@ EXPORT Bundle := MODULE(Std.BundleBase)
     EXPORT Copyright := 'Copyright (C) 2020 HPCC Systems';
     EXPORT DependsOn := [];
     EXPORT PlatformVersion := '6.0.0';
-    EXPORT Version := '1.0.1';
+    EXPORT Version := '1.1.0';
 END;


### PR DESCRIPTION
If TRUE, code will not check a file's content or format CRC values to determine if a file has been modified.  This significantly improves file scanning time at the expense of missing modified files.

Signed-off-by: Dan S. Camper <dan.camper@lexisnexisrisk.com>